### PR TITLE
Convert new-group-actions/gitlab-cicd-crash-course to GitHub Actions

### DIFF
--- a/.github/workflows/gitlab-cicd-crash-course.yml
+++ b/.github/workflows/gitlab-cicd-crash-course.yml
@@ -1,0 +1,55 @@
+name: new-group-actions/gitlab-cicd-crash-course
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build_image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Running make build..."
+  run_tests:
+    needs: build_image
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.9-slim-buster
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Updating package lists..."
+    - run: echo "Running make test..."
+  run_tests2:
+    needs: build_image
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.9-slim-buster
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Updating package lists2..."
+    - run: echo "Running make test2..."
+  deploy:
+    needs:
+    - run_tests
+    - run_tests2
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Running make deploy..."


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/new-group-actions/gitlab-cicd-crash-course) :tada: